### PR TITLE
Unity 2017 以降で動作しなかったため修正およびプロパティ追加

### DIFF
--- a/Assets/Shaders/FurHelper.cginc
+++ b/Assets/Shaders/FurHelper.cginc
@@ -1,9 +1,10 @@
 ﻿#ifndef EDO_FUR_SHADER_HELPER
 #define EDO_FUR_SHADER_HELPER
+#define EDO_FUR_SHADER_HELPER
 
 // 頂点シェーダへの入力構造体
 struct vertInput {
-	float4 vertex    : SV_POSITION;
+	float4 vertex    : POSITION;
 	float4 normal    : NORMAL;
 	float2 texcoord  : TEXCOORD0;
 	float2 texcoord2 : TEXCOORD1;
@@ -27,7 +28,7 @@ vert2frag vert(vertInput v) {
 	
 	vert2frag o;
 	
-	float3 forceDirection = float3(0.0);
+	float3 forceDirection = float3(0.0,0.0,0.0);
 	float4 position = v.vertex;
 	
 	// Wind

--- a/Assets/Shaders/FurHelper.cginc
+++ b/Assets/Shaders/FurHelper.cginc
@@ -1,4 +1,6 @@
-﻿#ifndef EDO_FUR_SHADER_HELPER
+﻿// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
+#ifndef EDO_FUR_SHADER_HELPER
 #define EDO_FUR_SHADER_HELPER
 #define EDO_FUR_SHADER_HELPER
 
@@ -21,6 +23,7 @@ struct vert2frag {
 uniform sampler2D _MainTex;
 uniform sampler2D _SubTex;
 uniform float4 _Gravity;
+uniform float _Roughness;
 
 vert2frag vert(vertInput v) {
 
@@ -44,9 +47,9 @@ vert2frag vert(vertInput v) {
 	
 	float4 n = normalize(aNormal) * FUR_OFFSET * spacing;
 	float4 wpos = float4(v.vertex.xyz + n.xyz, 1.0);
-	o.position = mul(UNITY_MATRIX_MVP, wpos);
+	o.position = UnityObjectToClipPos(wpos);
 	o.uv  = v.texcoord;
-	o.uv2 = v.texcoord2 * 10.0;
+	o.uv2 = v.texcoord2 * _Roughness;
 
 	return o;
 }

--- a/Assets/Shaders/FurShader.shader
+++ b/Assets/Shaders/FurShader.shader
@@ -3,6 +3,7 @@
 		_MainTex ("Base (RGB)", 2D) = "white" {}
 		_SubTex  ("Base (RGB)", 2D) = "white" {}
 		_Gravity ("Gravity", Vector) = (0.0, -0.75, 0.0, 0.0)
+		[PowerSlider(1.0)] _Roughness ("Roughness", Range (0.0, 100.0)) = 10.0
 	}
 	
 	Category {

--- a/Assets/Shaders/FurShader.shader
+++ b/Assets/Shaders/FurShader.shader
@@ -17,7 +17,9 @@
 				Blend Off
 			
 				CGPROGRAM
-				
+				#pragma vertex vert
+				#pragma fragment frag
+				#define FUR_OFFSET 0.000000
 				#include "FurHelper.cginc"
 				
 				ENDCG


### PR DESCRIPTION
- Unity 2017 以降で動作しなかったためエラーを解消して動作するようにしました。
  - `Windows 10`で `Unity 2017.4.28f1`,`Unity 2018.3.14f1`,`Unity 2019.1.2f1`にて動作確認しています。
- ついでに`Roughness`propertiesを追加しました。
  - uv座標を10倍している箇所をスライダーで調整できるようにしました。